### PR TITLE
Re-apply ƒix for Kubernetes dashboard rule (#2)

### DIFF
--- a/checkov/kubernetes/checks/resource/k8s/KubernetesDashboard.py
+++ b/checkov/kubernetes/checks/resource/k8s/KubernetesDashboard.py
@@ -19,8 +19,6 @@ class KubernetesDashboard(BaseK8sContainerCheck):
                 return CheckResult.FAILED
             if "kubernetes-dashboard" in conf_image or "kubernetesui" in conf_image:
                 return CheckResult.FAILED
-        else:
-            return CheckResult.FAILED
         if metadata and metadata.get("labels"):
             if "app" in metadata["labels"]:
                 if metadata["labels"]["app"] == "kubernetes-dashboard":

--- a/tests/kubernetes/checks/example_KubernetesDashboard/kube-dashboard-no-image-FAILED.yaml
+++ b/tests/kubernetes/checks/example_KubernetesDashboard/kube-dashboard-no-image-FAILED.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: kubernetes-dashboard
+spec:
+  containers:
+    - name: ccc

--- a/tests/kubernetes/checks/example_KubernetesDashboard/kube-dashboard-no-image-PASSED.yaml
+++ b/tests/kubernetes/checks/example_KubernetesDashboard/kube-dashboard-no-image-PASSED.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    aaa: bbb
+spec:
+  containers:
+    - name: ccc

--- a/tests/kubernetes/checks/test_KubernetesDashboard.py
+++ b/tests/kubernetes/checks/test_KubernetesDashboard.py
@@ -16,8 +16,8 @@ class TestKubernetesDashboard(unittest.TestCase):
         report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 1)
-        self.assertEqual(summary['failed'], 3)
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 4)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
