### PR TITLE
Check for 'SqsManagedSseEnabled' property in CKV AWS 27

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/SQSQueueEncryption.py
+++ b/checkov/cloudformation/checks/resource/aws/SQSQueueEncryption.py
@@ -1,11 +1,10 @@
 from typing import Any
 
-from checkov.common.models.enums import CheckCategories
-from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceValueCheck
-from checkov.common.models.consts import ANY_VALUE
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.cloudformation.checks.resource.base_resource_value_check import BaseResourceCheck
 
 
-class SQSQueueEncryption(BaseResourceValueCheck):
+class SQSQueueEncryption(BaseResourceCheck):
     def __init__(self) -> None:
         name = "Ensure all data stored in the SQS queue is encrypted"
         id = "CKV_AWS_27"
@@ -13,11 +12,13 @@ class SQSQueueEncryption(BaseResourceValueCheck):
         categories = [CheckCategories.ENCRYPTION]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
-    def get_inspected_key(self) -> str:
-        return 'Properties/KmsMasterKeyId'
-
-    def get_expected_value(self) -> Any:
-        return ANY_VALUE
+    def scan_resource_conf(self, conf: dict[str, list[Any]]) -> CheckResult:
+        if 'Properties' in conf and 'KmsMasterKeyId' in conf['Properties']:
+            return CheckResult.PASSED
+        if 'Properties' in conf and 'SqsManagedSseEnabled' in conf['Properties']:
+            if conf['Properties']['SqsManagedSseEnabled'] == True:
+                return CheckResult.PASSED
+        return CheckResult.FAILED
 
 
 check = SQSQueueEncryption()


### PR DESCRIPTION
```
Check: CKV_AWS_27: "Ensure all data stored in the SQS queue is encrypted"
        PASSED for resource: AWS::SQS::Queue.QueueWithSQSManagedSSE
        File: /yaokay.yaml:35-39
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-general-policies/general-16-encrypt-sqs-queue
Check: CKV_AWS_27: "Ensure all data stored in the SQS queue is encrypted"
        PASSED for resource: AWS::SQS::Queue.QueueWithKMSKey
        File: /yaokay.yaml:47-51
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-general-policies/general-16-encrypt-sqs-queue
Check: CKV_AWS_27: "Ensure all data stored in the SQS queue is encrypted"
        FAILED for resource: AWS::SQS::Queue.QueueWithoutEncryption
        File: /yaokay.yaml:30-33
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-general-policies/general-16-encrypt-sqs-queue

                30 |   QueueWithoutEncryption:
                31 |     Type: AWS::SQS::Queue
                32 |     Properties:
                33 |       QueueName: NoEncryptionQueue

Check: CKV_AWS_27: "Ensure all data stored in the SQS queue is encrypted"
        FAILED for resource: AWS::SQS::Queue.QueueWithSQSManagedSSEDisabled
        File: /yaokay.yaml:41-45
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-general-policies/general-16-encrypt-sqs-queue

                41 |   QueueWithSQSManagedSSEDisabled:
                42 |     Type: AWS::SQS::Queue
                43 |     Properties:
                44 |       QueueName: SSEDisabledQueue
                45 |       SqsManagedSseEnabled: false
 ```

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
