### PR TITLE
Support dict and list as value for CKV_AWS_37 rule

### DIFF
--- a/checkov/cloudformation/checks/resource/aws/EKSControlPlaneLogging.py
+++ b/checkov/cloudformation/checks/resource/aws/EKSControlPlaneLogging.py
@@ -31,7 +31,17 @@ class EKSControlPlaneLogging(BaseResourceCheck):
                 if cluster_logging and isinstance(cluster_logging, dict):
                     enabled_types = cluster_logging.get("EnabledTypes")
                     if enabled_types and isinstance(enabled_types, list):
-                        if all(elem in enabled_types for elem in log_types):
+                        # This normalizes the type, as either a dict or a list of strings could be passed down to `EnabledTypes`
+                        normalized: list[str] = []
+                        for t in enabled_types:
+                            if isinstance(t, str):
+                                normalized.append(t)
+                            elif isinstance(t, dict):
+                                type_value = t.get("Type")
+                                if isinstance(type_value, str):
+                                    normalized.append(type_value)
+
+                        if all(elem in normalized for elem in log_types):
                             return CheckResult.PASSED
         
         # By default, no logging is enabled

--- a/checkov/terraform/checks/resource/aws/EKSControlPlaneLogging.py
+++ b/checkov/terraform/checks/resource/aws/EKSControlPlaneLogging.py
@@ -3,7 +3,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 from typing import List
 
 
-class EKSControlPlaneLogging(BaseResourceCheck):
+class EKSControlPlaneLogging(BaseResourceCheck): 
     def __init__(self):
         name = "Ensure Amazon EKS control plane logging enabled for all log types"
         id = "CKV_AWS_37"

--- a/checkov/terraform/checks/resource/aws/EKSControlPlaneLogging.py
+++ b/checkov/terraform/checks/resource/aws/EKSControlPlaneLogging.py
@@ -3,7 +3,7 @@ from checkov.terraform.checks.resource.base_resource_check import BaseResourceCh
 from typing import List
 
 
-class EKSControlPlaneLogging(BaseResourceCheck): 
+class EKSControlPlaneLogging(BaseResourceCheck):
     def __init__(self):
         name = "Ensure Amazon EKS control plane logging enabled for all log types"
         id = "CKV_AWS_37"

--- a/tests/cloudformation/checks/resource/aws/example_EKSControlPlaneLogging/EKSControlPlaneLogging-PASSED-2.yml
+++ b/tests/cloudformation/checks/resource/aws/example_EKSControlPlaneLogging/EKSControlPlaneLogging-PASSED-2.yml
@@ -1,0 +1,28 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  EKSClusterWithLogging:
+    Type: AWS::EKS::Cluster
+    Properties:
+      Name: Prod
+      Version: '1.20'
+      RoleArn: 'arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRoleForAmazonEKS-EXAMPLEBQ4PI'
+      ResourcesVpcConfig:
+        SecurityGroupIds:
+          - sg-6979fe18
+        SubnetIds:
+          - subnet-6782e71e
+          - subnet-e7e761ac
+        EndpointPublicAccess: false
+        EndpointPrivateAccess: true
+        PublicAccessCidrs: ['1.1.1.2/32']
+      Logging:
+        ClusterLogging:
+          EnabledTypes:
+            - Type: api
+            - Type: audit
+            - Type: authenticator
+            - Type: controllerManager
+            - Type: scheduler
+      Tags:
+        - Key: 'key'
+          Value: 'val'

--- a/tests/cloudformation/checks/resource/aws/test_EKSControlPlaneLogging.py
+++ b/tests/cloudformation/checks/resource/aws/test_EKSControlPlaneLogging.py
@@ -17,7 +17,7 @@ class TestEKSControlPlaneLogging(unittest.TestCase):
                             runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 
-        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['passed'], 2)
         self.assertEqual(summary['failed'], 2)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Enhanced EKS control plane logging check to accept dict and list values


<sup>[More info](https://app.aikido.dev/featurebranch/scan/90246178?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->