### PR TITLE
Port chore: enable mypy for kubernetes.checks to CKV_K8S_23

### DIFF
--- a/checkov/common/images/image_referencer.py
+++ b/checkov/common/images/image_referencer.py
@@ -5,7 +5,7 @@ import logging
 from abc import abstractmethod
 from collections.abc import Iterable
 from pathlib import Path
-from typing import cast, Any, TYPE_CHECKING, Generic, TypeVar
+from typing import Any, TYPE_CHECKING, Generic, TypeVar
 
 import aiohttp
 import docker
@@ -103,8 +103,8 @@ class ImageReferencer:
                 image = client.images.get(image_name)
             except Exception:
                 image = client.images.pull(image_name)
-                return cast(str, image.short_id)
-            return cast(str, image.short_id)
+                return image.short_id
+            return image.short_id
         except Exception:
             logging.debug(f"failed to pull docker image={image_name}", exc_info=True)
             return ""

--- a/checkov/kubernetes/checks/resource/base_spec_check.py
+++ b/checkov/kubernetes/checks/resource/base_spec_check.py
@@ -4,7 +4,6 @@ from typing import Dict, Any, Optional
 
 from checkov.common.checks.base_check import BaseCheck
 from checkov.common.models.enums import CheckCategories, CheckResult
-from checkov.common.multi_signature import multi_signature
 from checkov.kubernetes.checks.resource.registry import registry
 
 
@@ -30,26 +29,9 @@ class BaseK8Check(BaseCheck):
 
     def scan_entity_conf(self, conf: Dict[str, Any], entity_type: str) -> CheckResult:
         self.entity_type = entity_type
-        return self.scan_spec_conf(conf, entity_type)
+        return self.scan_spec_conf(conf)
 
-    @multi_signature()
     @abstractmethod
-    def scan_spec_conf(self, conf: Dict[str, Any], entity_type: str) -> CheckResult:
+    def scan_spec_conf(self, conf: Dict[str, Any]) -> CheckResult:
         """Return result of Kubernetes object check."""
         raise NotImplementedError()
-
-    @classmethod
-    @scan_spec_conf.add_signature(args=["self", "conf"])
-    def _scan_spec_conf_self_conf(cls, wrapped):
-        def wrapper(self, conf, entity_type=None):
-            # keep default argument for entity_type so old code, that doesn't set it, will work.
-            return wrapped(self, conf)
-
-        return wrapper
-
-    @staticmethod
-    def get_inner_entry(conf: Dict[str, Any], entry_name: str) -> Dict[str, Any]:
-        spec = {}
-        if conf.get("spec") and isinstance(conf["spec"], dict) and conf.get("spec").get("template"):
-            spec = conf.get("spec").get("template").get(entry_name, {})
-        return spec

--- a/checkov/kubernetes/checks/resource/k8s/RootContainers.py
+++ b/checkov/kubernetes/checks/resource/k8s/RootContainers.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
+from typing import Any
+
 from checkov.common.models.enums import CheckResult
 from checkov.kubernetes.checks.resource.base_root_container_check import BaseK8sRootContainerCheck
 
 
 class RootContainers(BaseK8sRootContainerCheck):
-    def __init__(self):
+    def __init__(self) -> None:
         # CIS-1.3 1.7.6
         # CIS-1.5 5.2.6
         name = "Minimize the admission of root containers"
@@ -14,12 +18,12 @@ class RootContainers(BaseK8sRootContainerCheck):
         id = "CKV_K8S_23"
         super().__init__(name=name, id=id)
 
-    def scan_spec_conf(self, conf):
+    def scan_spec_conf(self, conf: dict[str, Any]) -> CheckResult:
         spec = self.extract_spec(conf)
 
         # Collect results
         if spec and isinstance(spec, dict):
-            results = {"pod": {}, "container": []}
+            results: dict[str, Any] = {"pod": {}, "container": []}
             results["pod"]["runAsNonRoot"] = self.check_runAsNonRoot(spec)
             results["pod"]["runAsUser"] = self.check_runAsUser(spec, 1)
 

--- a/extra_stubs/docker/__init__.pyi
+++ b/extra_stubs/docker/__init__.pyi
@@ -1,0 +1,13 @@
+from typing import Any
+
+from .models.images import ImageCollection
+
+class DockerClient:
+    @classmethod
+    def from_env(cls, **kwargs: Any) -> DockerClient: ...
+
+    @property
+    def images(self) -> ImageCollection: ...
+
+
+from_env = DockerClient.from_env

--- a/extra_stubs/docker/client.pyi
+++ b/extra_stubs/docker/client.pyi
@@ -1,0 +1,13 @@
+from typing import Any
+
+from .models.images import ImageCollection
+
+class DockerClient:
+    @classmethod
+    def from_env(cls, **kwargs: Any) -> DockerClient: ...
+
+    @property
+    def images(self) -> ImageCollection: ...
+
+
+from_env = DockerClient.from_env

--- a/extra_stubs/docker/models/images.pyi
+++ b/extra_stubs/docker/models/images.pyi
@@ -1,0 +1,14 @@
+from typing import Any
+
+
+class Image:
+    attrs: dict[str, Any]
+    @property
+    def id(self) -> str: ...  # is actually defined in its parent class 'Model'
+    @property
+    def short_id(self) -> str: ...
+
+
+class ImageCollection:
+    def get(self, name: str) -> Image: ...
+    def pull(self, repository: str, tag: str | None= ..., all_tags: bool = ..., **kwargs: Any) -> Image: ...

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,19 +2,13 @@
 mypy_path = extra_stubs
 
 files = checkov
-exclude = checkov/(arm/checks|cloudformation/checks|kubernetes/checks|serverless|terraform/(checks|parser.py|plan_runner.py|runner.py))
+exclude = checkov/(cloudformation/checks|serverless|terraform/checks)
 strict = True
 disallow_subclassing_any = False
 implicit_reexport = True
 show_error_codes = True
 
 [mypy-configargparse.*]
-ignore_missing_imports = True
-
-[mypy-deep_merge.*]
-ignore_missing_imports = True
-
-[mypy-docker.*]
 ignore_missing_imports = True
 
 [mypy-dpath.*]
@@ -24,12 +18,6 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-networkx.*]
-ignore_missing_imports = True
-
-[mypy-spdx.*]
-ignore_missing_imports = True
-
-[mypy-license_expression.*]
 ignore_missing_imports = True
 
 [mypy-checkov.*]


### PR DESCRIPTION
Porting - chore: enable mypy for kubernetes.checks (https://github.com/bridgecrewio/checkov/pull/5722)

** Alert **

It may conflict/crash or not work fully as expected because `break(general): remove multi_signature and adjust base check classes (https://github.com/bridgecrewio/checkov/pull/5645)` that was not added into our fork yet 