### PR TITLE
Filter directories which were scanned with Kustomize from results

### DIFF
--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -15,6 +15,7 @@ from typing import List, Dict, Any, Optional, cast, TYPE_CHECKING, Type
 from typing_extensions import Literal
 
 from checkov.common.bridgecrew.code_categories import CodeCategoryMapping, CodeCategoryType
+from checkov.common.bridgecrew.platform_errors import ModuleNotEnabledError
 from checkov.common.bridgecrew.platform_integration import bc_integration
 from checkov.common.bridgecrew.integration_features.features.policy_metadata_integration import \
     integration as metadata_integration

--- a/checkov/common/runners/runner_registry.py
+++ b/checkov/common/runners/runner_registry.py
@@ -23,7 +23,7 @@ from checkov.common.bridgecrew.integration_features.features.repo_config_integra
 from checkov.common.bridgecrew.integration_features.features.licensing_integration import \
     integration as licensing_integration
 from checkov.common.bridgecrew.integration_features.integration_feature_registry import integration_feature_registry
-from checkov.common.bridgecrew.platform_errors import ModuleNotEnabledError
+from checkov.common.bridgecrew.check_type import CheckType
 from checkov.common.bridgecrew.severities import Severities
 from checkov.common.images.image_referencer import ImageReferencer
 from checkov.common.models.enums import ErrorStatus
@@ -46,6 +46,7 @@ from checkov.secrets.consts import SECRET_VALIDATION_STATUSES
 from checkov.terraform.context_parsers.registry import parser_registry
 from checkov.terraform.parser import Parser
 from checkov.terraform.runner import Runner as tf_runner
+from checkov.kustomize.runner import filter_kubernetes_report_for_kustomize_dirs
 
 if TYPE_CHECKING:
     from checkov.common.output.baseline import Baseline
@@ -107,6 +108,7 @@ class RunnerRegistry:
             collect_skip_comments: bool = True,
             repo_root_for_plan_enrichment: list[str | Path] | None = None,
     ) -> list[Report]:
+        kustomize_managed_dirs: set[str] = set()
         if not self.runners:
             logging.error('There are no runners to run. This can happen if you specify a file type and a framework that are not compatible '
                           '(e.g., `--file xyz.yaml --framework terraform`), or if you specify a framework with missing dependencies (e.g., '
@@ -119,11 +121,15 @@ class RunnerRegistry:
                     self.runners[0].run(root_folder, external_checks_dir=external_checks_dir, files=files,
                                         runner_filter=self.runner_filter,
                                         collect_skip_comments=collect_skip_comments)]
+                if runner_check_type == CheckType.KUSTOMIZE:
+                    kustomize_managed_dirs = getattr(self.runners[0], 'managed_directories', set()) or set()
             else:
                 # This is the only runner, so raise a clear indication of failure
                 raise ModuleNotEnabledError(f'The framework "{runner_check_type}" is part of the "{self.licensing_integration.get_subscription_for_runner(runner_check_type).name}" module, which is not enabled in the platform')
         else:
-            def _parallel_run(runner: _BaseRunner) -> tuple[Report | list[Report], str | None, DiGraph | Graph | None]:
+            def _parallel_run(
+                runner: _BaseRunner,
+            ) -> tuple[Report | list[Report], str | None, DiGraph | Graph | None, set[str] | None]:
                 report = runner.run(
                     root_folder=root_folder,
                     external_checks_dir=external_checks_dir,
@@ -136,9 +142,13 @@ class RunnerRegistry:
                     logging.error(f"Failed to create report for {runner.check_type} framework")
                     report = Report(check_type=runner.check_type)
 
+                managed_dirs = None
+                if runner.check_type == CheckType.KUSTOMIZE:
+                    managed_dirs = getattr(runner, 'managed_directories', None)
+
                 if runner.graph_manager:
-                    return report, runner.check_type, runner.graph_manager.get_reader_endpoint()
-                return report, None, None
+                    return report, runner.check_type, runner.graph_manager.get_reader_endpoint(), managed_dirs
+                return report, None, None, managed_dirs
 
             valid_runners = []
             invalid_runners = []
@@ -171,13 +181,16 @@ class RunnerRegistry:
             full_check_type_to_graph = {}
             for result in parallel_runner_results:
                 if result is not None:
-                    report, check_type, graph = result
+                    report, check_type, graph, managed_dirs = result
                     reports.append(report)
                     if check_type is not None and graph is not None:
                         full_check_type_to_graph[check_type] = graph
+                    if managed_dirs:
+                        kustomize_managed_dirs.update(managed_dirs)
             self.check_type_to_graph = full_check_type_to_graph
 
         merged_reports = self._merge_reports(reports)
+        self._filter_kubernetes_kustomize_overlap(merged_reports, kustomize_managed_dirs)
         if bc_integration.bc_api_key:
             self.secrets_omitter_class(merged_reports).omit()
 
@@ -632,6 +645,30 @@ class RunnerRegistry:
         if "all" in self.runner_filter.framework:
             return
         self.runners = [runner for runner in self.runners if runner.check_type in self.runner_filter.framework]
+
+    def _filter_kubernetes_kustomize_overlap(
+        self,
+        reports: list[Report],
+        kustomize_managed_dirs: set[str],
+    ) -> None:
+        if not self.runner_filter or not kustomize_managed_dirs:
+            return
+
+        framework = self.runner_filter.framework
+        if CheckType.KUSTOMIZE not in framework and "all" not in framework:
+            return
+
+        runner_types = {runner.check_type for runner in self.runners}
+        if CheckType.KUBERNETES not in runner_types or CheckType.KUSTOMIZE not in runner_types:
+            return
+
+        for report in reports:
+            filter_kubernetes_report_for_kustomize_dirs(report, kustomize_managed_dirs)
+
+        logging.debug(
+            "Removed kubernetes findings under %d kustomize directories after scan",
+            len(kustomize_managed_dirs),
+        )
 
     def filter_runners_for_files(self, files: List[str]) -> None:
         if not files:

--- a/checkov/kustomize/runner.py
+++ b/checkov/kustomize/runner.py
@@ -378,6 +378,7 @@ class Runner(BaseRunner["KubernetesGraphManager"]):
         self.potentialBases: "list[str]" = []
         self.potentialOverlays: "list[str]" = []
         self.kustomizeProcessedFolderAndMeta: "dict[str, dict[str, str]]" = {}
+        self.managed_directories: set[str] = set()
         self.kustomizeFileMappings: "dict[str, str]" = {}
         self.templateRendererCommand: str | None = None
         self.target_folder_path = ''
@@ -649,7 +650,10 @@ class Runner(BaseRunner["KubernetesGraphManager"]):
     def run_kustomize_to_k8s(
         self, root_folder: str | None, files: list[str] | None, runner_filter: RunnerFilter
     ) -> None:
-        kustomize_dirs = find_kustomize_directories(root_folder, files, runner_filter.excluded_paths)
+        self.managed_directories = set()
+        kustomize_dirs = find_kustomize_directories(
+            root_folder, files, runner_filter.excluded_paths, self.managed_directories
+        )
         if not kustomize_dirs:
             # nothing to process
             return
@@ -853,16 +857,25 @@ def filter_path_nested_kustomize_directories(kustomize_directories: list[str]) -
     ]
 
 
-def filter_root_kustomize_directories(kustomize_directories: list[str]) -> list[str]:
+def filter_root_kustomize_directories(
+    kustomize_directories: list[str],
+    managed_directories: set[str] | None = None,
+) -> list[str]:
     """
     Keep only kustomization roots (not referenced as resources/bases/components by another
     kustomization in the same scan). Intermediate component kustomizations are composed by
     their parent `kustomize build` and should not be built in isolation.
+
+    Managed directories are directories that are managed by the kustomize runner, and is by reference passed
+    to the kubernetes runner to skip scanning for kubernetes checks.
     """
+    abs_dirs = {os.path.abspath(d) for d in kustomize_directories}
+    if managed_directories is not None:
+        managed_directories.update(abs_dirs)
+
     if len(kustomize_directories) <= 1:
         return kustomize_directories
 
-    abs_dirs = {os.path.abspath(d) for d in kustomize_directories}
     referenced: set[str] = set()
     for kustomize_dir in kustomize_directories:
         for ref in _get_kustomization_directory_refs(kustomize_dir):
@@ -887,7 +900,10 @@ def filter_root_kustomize_directories(kustomize_directories: list[str]) -> list[
 
 
 def find_kustomize_directories(
-    root_folder: str | None, files: list[str] | None, excluded_paths: list[str]
+    root_folder: str | None,
+    files: list[str] | None,
+    excluded_paths: list[str],
+    managed_directories: set[str] | None = None,
 ) -> list[str]:
     kustomize_directories = []
     if not excluded_paths:
@@ -897,8 +913,7 @@ def find_kustomize_directories(
         for file in files:
             if os.path.basename(file) in Runner.kustomizeSupportedFileTypes:
                 kustomize_directories.append(os.path.dirname(file))
-        # As individual files are provided, it's not needed to filter nested kustomization files
-        return kustomize_directories
+        return filter_root_kustomize_directories(kustomize_directories, managed_directories)
 
     if root_folder:
         for root, d_names, f_names in os.walk(root_folder):
@@ -909,4 +924,27 @@ def find_kustomize_directories(
             )
 
     kustomize_directories = filter_path_nested_kustomize_directories(kustomize_directories)
-    return filter_root_kustomize_directories(kustomize_directories)
+    return filter_root_kustomize_directories(kustomize_directories, managed_directories)
+
+
+def is_path_under_kustomize_dir(file_path: str, kustomize_dirs: set[str]) -> bool:
+    abs_path = os.path.abspath(file_path)
+    return any(
+        abs_path == kustomize_dir or abs_path.startswith(kustomize_dir + os.sep)
+        for kustomize_dir in kustomize_dirs
+    )
+
+
+def filter_kubernetes_report_for_kustomize_dirs(report: Report, kustomize_dirs: set[str]) -> None:
+    if report.check_type != CheckType.KUBERNETES or not kustomize_dirs:
+        return
+
+    report.failed_checks = [
+        record for record in report.failed_checks
+        if not is_path_under_kustomize_dir(record.file_abs_path, kustomize_dirs)
+    ]
+
+    report.passed_checks = [
+        record for record in report.passed_checks
+        if not is_path_under_kustomize_dir(record.file_abs_path, kustomize_dirs)
+    ]

--- a/tests/kubernetes/test_kustomize_managed_files_skip.py
+++ b/tests/kubernetes/test_kustomize_managed_files_skip.py
@@ -1,0 +1,67 @@
+import os
+import unittest
+
+from checkov.common.runners.runner_registry import RunnerRegistry
+from checkov.kubernetes.checks.resource.k8s.ContainerSecurityContext import check
+from checkov.kubernetes.runner import Runner as KubernetesRunner
+from checkov.kustomize.runner import (
+    Runner as KustomizeRunner,
+    filter_kubernetes_report_for_kustomize_dirs,
+    find_kustomize_directories,
+)
+from checkov.kubernetes.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+EXAMPLE = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    "kustomize",
+    "runner",
+    "resources",
+    "example",
+)
+
+
+class TestKustomizeManagedFilesSkip(unittest.TestCase):
+    def test_post_processing_removes_kubernetes_findings_under_kustomize_dirs(self):
+        root = os.path.abspath(EXAMPLE)
+        runner_filter = RunnerFilter(framework=["kubernetes", "kustomize"], checks=[check.id])
+        registry = RunnerRegistry("", runner_filter, KubernetesRunner(), KustomizeRunner())
+        reports = registry.run(root_folder=root)
+
+        kubernetes_report = next(report for report in reports if report.check_type == "kubernetes")
+        failed_files = {record.file_abs_path for record in kubernetes_report.failed_checks}
+        managed_deployment = os.path.abspath(os.path.join(root, "base", "deployment.yaml"))
+        self.assertNotIn(managed_deployment, failed_files)
+
+    def test_kubernetes_runner_still_scans_kustomize_dirs_before_post_processing(self):
+        root = os.path.abspath(EXAMPLE)
+        runner = Runner()
+        report = runner.run(
+            root_folder=root,
+            runner_filter=RunnerFilter(framework=["kubernetes"], checks=[check.id]),
+        )
+
+        failed_files = {record.file_abs_path for record in report.failed_checks}
+        managed_deployment = os.path.abspath(os.path.join(root, "base", "deployment.yaml"))
+        self.assertIn(managed_deployment, failed_files)
+
+    def test_filter_kubernetes_report_for_kustomize_dirs(self):
+        root = os.path.abspath(EXAMPLE)
+        runner = Runner()
+        report = runner.run(
+            root_folder=root,
+            runner_filter=RunnerFilter(framework=["kubernetes"], checks=[check.id]),
+        )
+        self.assertTrue(report.failed_checks)
+
+        managed_directories: set[str] = set()
+        find_kustomize_directories(root, None, [], managed_directories)
+        filter_kubernetes_report_for_kustomize_dirs(report, managed_directories)
+
+        failed_files = {record.file_abs_path for record in report.failed_checks}
+        managed_deployment = os.path.abspath(os.path.join(root, "base", "deployment.yaml"))
+        self.assertNotIn(managed_deployment, failed_files)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 3 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Excluded directories managed by Kustomize from final scan results
* Propagated Kustomize managed_directories from runners in parallel execution

**🔧 Refactors**
* Reordered and reintroduced ModuleNotEnabledError import for clarity


<sup>[More info](https://app.aikido.dev/featurebranch/scan/131993141?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->