### PR TITLE
Fix graph edges between count-expanded Terraform resources

### DIFF
--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -235,52 +235,71 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
                 aliases=aliases,
                 resources_types=resources_types,
             )
-            for vertex_reference in referenced_vertices:
+            indexed_referenced_vertices = get_referenced_vertices_in_value(
+                value=attribute_value,
+                aliases=aliases,
+                resources_types=resources_types,
+                preserve_resource_index=True,
+            )
+            merged_referenced_vertices: list[TerraformVertexReference] = []
+            for vertex_reference in referenced_vertices + indexed_referenced_vertices:
+                if vertex_reference not in merged_referenced_vertices:
+                    merged_referenced_vertices.append(vertex_reference)
+            for vertex_reference in merged_referenced_vertices:
                 # for certain blocks such as data and resource, the block name is composed from several parts.
                 # the purpose of the loop is to avoid not finding the node if the name has several parts
-                sub_values = [remove_index_pattern_from_str(sub_value) for sub_value in vertex_reference.sub_parts]
-                for i in range(len(sub_values)):
-                    reference_name = join_trimmed_strings(char_to_join=".", str_lst=sub_values, num_to_trim=i)
-                    source_module_object = None
-                    if self.use_new_tf_parser:
-                        source_module_object = vertex.source_module_object
-                    if referenced_modules is not None:
-                        for module in referenced_modules:
-                            referenced_module_idx = module.get("idx")
-                            referenced_module_path = module.get("path")
-                            referenced_module_object = module.get("source_module_object")
-                            if not self.use_new_tf_parser:
-                                source_module_object = referenced_module_object if source_module_object else None
-                            if referenced_module_path is None:
-                                dest_node_index = -1
-                            else:
-                                dest_node_index = self._find_vertex_index_relative_to_path(
-                                    vertex_reference.block_type, reference_name, referenced_module_path,
-                                    vertex.module_dependency,
-                                    vertex.module_dependency_num, referenced_module_idx,
-                                    source_module_object=source_module_object
-                                )
-                            self._create_edge_from_reference(attribute_key, origin_node_index, dest_node_index,
-                                                             sub_values, vertex_reference, cross_variable_edges)
-                    if vertex.module_dependency or hasattr(vertex, "source_module_object"):
-                        dest_node_index = self._find_vertex_index_relative_to_path(
-                            vertex_reference.block_type, reference_name, vertex.path, vertex.module_dependency,
-                            vertex.module_dependency_num, source_module_object=source_module_object
-                        )
-                        if dest_node_index == -1:
+                sub_values_variants = [
+                    vertex_reference.sub_parts,
+                    [remove_index_pattern_from_str(sub_value) for sub_value in vertex_reference.sub_parts],
+                ]
+                edge_created = False
+                for sub_values in sub_values_variants:
+                    if edge_created:
+                        break
+                    for i in range(len(sub_values)):
+                        reference_name = join_trimmed_strings(char_to_join=".", str_lst=sub_values, num_to_trim=i)
+                        source_module_object = None
+                        if self.use_new_tf_parser:
+                            source_module_object = vertex.source_module_object
+                        if referenced_modules is not None:
+                            for module in referenced_modules:
+                                referenced_module_idx = module.get("idx")
+                                referenced_module_path = module.get("path")
+                                referenced_module_object = module.get("source_module_object")
+                                if not self.use_new_tf_parser:
+                                    source_module_object = referenced_module_object if source_module_object else None
+                                if referenced_module_path is None:
+                                    dest_node_index = -1
+                                else:
+                                    dest_node_index = self._find_vertex_index_relative_to_path(
+                                        vertex_reference.block_type, reference_name, referenced_module_path,
+                                        vertex.module_dependency,
+                                        vertex.module_dependency_num, referenced_module_idx,
+                                        source_module_object=source_module_object
+                                    )
+                                self._create_edge_from_reference(attribute_key, origin_node_index, dest_node_index,
+                                                                 sub_values, vertex_reference, cross_variable_edges)
+                        dest_node_index = -1
+                        if vertex.module_dependency or hasattr(vertex, "source_module_object"):
                             dest_node_index = self._find_vertex_index_relative_to_path(
-                                vertex_reference.block_type, reference_name, vertex.path, vertex.path,
+                                vertex_reference.block_type, reference_name, vertex.path, vertex.module_dependency,
                                 vertex.module_dependency_num, source_module_object=source_module_object
                             )
-                    else:
-                        dest_node_index = self._find_vertex_index_relative_to_path(
-                            vertex_reference.block_type, reference_name, vertex.path, vertex.module_dependency,
-                            vertex.module_dependency_num, source_module_object=source_module_object
-                        )
-                    if dest_node_index > -1 and origin_node_index > -1:
-                        self._create_edge_from_reference(attribute_key, origin_node_index, dest_node_index, sub_values,
-                                                         vertex_reference, cross_variable_edges)
-                        break
+                            if dest_node_index == -1:
+                                dest_node_index = self._find_vertex_index_relative_to_path(
+                                    vertex_reference.block_type, reference_name, vertex.path, vertex.path,
+                                    vertex.module_dependency_num, source_module_object=source_module_object
+                                )
+                        else:
+                            dest_node_index = self._find_vertex_index_relative_to_path(
+                                vertex_reference.block_type, reference_name, vertex.path, vertex.module_dependency,
+                                vertex.module_dependency_num, source_module_object=source_module_object
+                            )
+                        if dest_node_index > -1 and origin_node_index > -1:
+                            self._create_edge_from_reference(attribute_key, origin_node_index, dest_node_index, sub_values,
+                                                             vertex_reference, cross_variable_edges)
+                            edge_created = True
+                            break
 
         if vertex.block_type == BlockType.MODULE and vertex.attributes.get('source') \
                 and isinstance(vertex.attributes['source'][0], str):

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -32,6 +32,7 @@ from checkov.terraform.graph_builder.utils import (
     get_attribute_is_leaf,
     get_referenced_vertices_in_value,
     attribute_has_nested_attributes, remove_index_pattern_from_str,
+    resource_reference_lookup_variants,
 )
 from checkov.terraform.graph_builder.utils import is_local_path
 from checkov.terraform.graph_builder.variable_rendering.renderer import TerraformVariableRenderer
@@ -248,10 +249,7 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
             for vertex_reference in merged_referenced_vertices:
                 # for certain blocks such as data and resource, the block name is composed from several parts.
                 # the purpose of the loop is to avoid not finding the node if the name has several parts
-                sub_values_variants = [
-                    vertex_reference.sub_parts,
-                    [remove_index_pattern_from_str(sub_value) for sub_value in vertex_reference.sub_parts],
-                ]
+                sub_values_variants = resource_reference_lookup_variants(vertex_reference.sub_parts)
                 edge_created = False
                 for sub_values in sub_values_variants:
                     if edge_created:

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -31,7 +31,7 @@ from checkov.terraform.graph_builder.graph_components.module import Module
 from checkov.terraform.graph_builder.utils import (
     get_attribute_is_leaf,
     get_referenced_vertices_in_value,
-    attribute_has_nested_attributes, remove_index_pattern_from_str,
+    attribute_has_nested_attributes,
     resource_reference_lookup_variants,
 )
 from checkov.terraform.graph_builder.utils import is_local_path

--- a/checkov/terraform/graph_builder/local_graph.py
+++ b/checkov/terraform/graph_builder/local_graph.py
@@ -235,18 +235,9 @@ class TerraformLocalGraph(LocalGraph[TerraformBlock]):
                 value=attribute_value,
                 aliases=aliases,
                 resources_types=resources_types,
+                include_indexed_references=True,
             )
-            indexed_referenced_vertices = get_referenced_vertices_in_value(
-                value=attribute_value,
-                aliases=aliases,
-                resources_types=resources_types,
-                preserve_resource_index=True,
-            )
-            merged_referenced_vertices: list[TerraformVertexReference] = []
-            for vertex_reference in referenced_vertices + indexed_referenced_vertices:
-                if vertex_reference not in merged_referenced_vertices:
-                    merged_referenced_vertices.append(vertex_reference)
-            for vertex_reference in merged_referenced_vertices:
+            for vertex_reference in referenced_vertices:
                 # for certain blocks such as data and resource, the block name is composed from several parts.
                 # the purpose of the loop is to avoid not finding the node if the name has several parts
                 sub_values_variants = resource_reference_lookup_variants(vertex_reference.sub_parts)

--- a/checkov/terraform/graph_builder/utils.py
+++ b/checkov/terraform/graph_builder/utils.py
@@ -209,6 +209,7 @@ def get_referenced_vertices_in_value(
         value: Union[str, List[str], Dict[str, str]],
         aliases: Dict[str, Dict[str, str]],
         resources_types: List[str],
+        preserve_resource_index: bool = False,
 ) -> List[TerraformVertexReference]:
     references_vertices: "list[TerraformVertexReference]" = []
 
@@ -219,13 +220,13 @@ def get_referenced_vertices_in_value(
     if isinstance(value, list):
         for sub_value in value:
             references_vertices += get_referenced_vertices_in_value(
-                sub_value, aliases, resources_types
+                sub_value, aliases, resources_types, preserve_resource_index
             )
 
     if isinstance(value, dict):
         for sub_value in value.values():
             references_vertices += get_referenced_vertices_in_value(
-                sub_value, aliases, resources_types
+                sub_value, aliases, resources_types, preserve_resource_index
             )
 
     if isinstance(value, str):
@@ -233,6 +234,7 @@ def get_referenced_vertices_in_value(
             str_value=value,
             aliases=aliases,
             resources_types=resources_types,
+            preserve_resource_index=preserve_resource_index,
         )
 
     return references_vertices
@@ -242,6 +244,7 @@ def get_referenced_vertices_in_str_value(
     str_value: str,
     aliases: dict[str, dict[str, str]],
     resources_types: list[str],
+    preserve_resource_index: bool = False,
 ) -> list[TerraformVertexReference]:
     references_vertices: "list[TerraformVertexReference]" = []
 
@@ -258,7 +261,8 @@ def get_referenced_vertices_in_str_value(
             return references_vertices
 
         str_value = remove_function_calls_from_str(str_value=str_value)
-        str_value = remove_index_pattern_from_str(str_value=str_value)
+        if not preserve_resource_index:
+            str_value = remove_index_pattern_from_str(str_value=str_value)
         str_value = replace_map_attribute_access_with_dot(str_value=str_value)
         str_value = remove_interpolation(str_value=str_value)
 

--- a/checkov/terraform/graph_builder/utils.py
+++ b/checkov/terraform/graph_builder/utils.py
@@ -180,6 +180,25 @@ def remove_index_pattern_from_str(str_value: str) -> str:
     return str_value
 
 
+def normalize_terraform_resource_index_name(resource_name: str) -> str:
+    """Convert foo[\"0\"] style resource names to foo[0] for graph vertex lookup."""
+    return re.sub(r'\[(["\'])([^"\']+)\1\]', r'[\2]', resource_name)
+
+
+def resource_reference_lookup_variants(sub_parts: list[str]) -> list[list[str]]:
+    variants: list[list[str]] = [sub_parts]
+    stripped = [remove_index_pattern_from_str(sub_value) for sub_value in sub_parts]
+    if stripped not in variants:
+        variants.append(stripped)
+    normalized = [normalize_terraform_resource_index_name(sub_value) for sub_value in sub_parts]
+    if normalized not in variants:
+        variants.append(normalized)
+    normalized_stripped = [remove_index_pattern_from_str(s) for s in normalized]
+    if normalized_stripped not in variants:
+        variants.append(normalized_stripped)
+    return variants
+
+
 def remove_interpolation(str_value: str) -> str:
     if "${" not in str_value:
         # otherwise it can't be a string interpolation

--- a/checkov/terraform/graph_builder/utils.py
+++ b/checkov/terraform/graph_builder/utils.py
@@ -228,7 +228,7 @@ def get_referenced_vertices_in_value(
         value: Union[str, List[str], Dict[str, str]],
         aliases: Dict[str, Dict[str, str]],
         resources_types: List[str],
-        preserve_resource_index: bool = False,
+        include_indexed_references: bool = False,
 ) -> List[TerraformVertexReference]:
     references_vertices: "list[TerraformVertexReference]" = []
 
@@ -239,13 +239,13 @@ def get_referenced_vertices_in_value(
     if isinstance(value, list):
         for sub_value in value:
             references_vertices += get_referenced_vertices_in_value(
-                sub_value, aliases, resources_types, preserve_resource_index
+                sub_value, aliases, resources_types, include_indexed_references
             )
 
     if isinstance(value, dict):
         for sub_value in value.values():
             references_vertices += get_referenced_vertices_in_value(
-                sub_value, aliases, resources_types, preserve_resource_index
+                sub_value, aliases, resources_types, include_indexed_references
             )
 
     if isinstance(value, str):
@@ -253,7 +253,7 @@ def get_referenced_vertices_in_value(
             str_value=value,
             aliases=aliases,
             resources_types=resources_types,
-            preserve_resource_index=preserve_resource_index,
+            include_indexed_references=include_indexed_references,
         )
 
     return references_vertices
@@ -263,7 +263,7 @@ def get_referenced_vertices_in_str_value(
     str_value: str,
     aliases: dict[str, dict[str, str]],
     resources_types: list[str],
-    preserve_resource_index: bool = False,
+    include_indexed_references: bool = False,
 ) -> list[TerraformVertexReference]:
     references_vertices: "list[TerraformVertexReference]" = []
 
@@ -280,12 +280,24 @@ def get_referenced_vertices_in_str_value(
             return references_vertices
 
         str_value = remove_function_calls_from_str(str_value=str_value)
-        if not preserve_resource_index:
-            str_value = remove_index_pattern_from_str(str_value=str_value)
-        str_value = replace_map_attribute_access_with_dot(str_value=str_value)
-        str_value = remove_interpolation(str_value=str_value)
+        stripped_value = remove_index_pattern_from_str(str_value=str_value)
+        references_vertices = get_vertices_references(
+            remove_interpolation(replace_map_attribute_access_with_dot(stripped_value)),
+            aliases,
+            resources_types,
+        )
 
-        references_vertices = get_vertices_references(str_value, aliases, resources_types)
+        if include_indexed_references and stripped_value != str_value:
+            # the value contains an index access (e.g. 'aws_s3_bucket.replay[0].id'), so additionally
+            # collect references with the index preserved to match count/for_each expanded vertices
+            indexed_references = get_vertices_references(
+                remove_interpolation(replace_map_attribute_access_with_dot(str_value)),
+                aliases,
+                resources_types,
+            )
+            for vertex_reference in indexed_references:
+                if vertex_reference not in references_vertices:
+                    references_vertices.append(vertex_reference)
 
     return references_vertices
 

--- a/checkov/terraform/graph_builder/utils.py
+++ b/checkov/terraform/graph_builder/utils.py
@@ -65,6 +65,7 @@ BLOCK_TYPES_STRINGS = ("var", "local", "module", "data")
 FUNC_CALL_PREFIX_PATTERN = re.compile(r"([.a-zA-Z]+)\(")
 INTERPOLATION_EXPR = re.compile(r"\$\{([^\}]*)\}")
 INDEX_PATTERN = re.compile(r"\[([0-9]+)\]")
+QUOTED_INDEX_PATTERN = re.compile(r"\[([\"'])([^\"']+)\1\]")
 MAP_ATTRIBUTE_PATTERN = re.compile(r"\[\"([^\d\W]\w*)\"\]")
 NESTED_ATTRIBUTE_PATTERN = re.compile(r"\.\d+")
 
@@ -182,7 +183,11 @@ def remove_index_pattern_from_str(str_value: str) -> str:
 
 def normalize_terraform_resource_index_name(resource_name: str) -> str:
     """Convert foo[\"0\"] style resource names to foo[0] for graph vertex lookup."""
-    return re.sub(r'\[(["\'])([^"\']+)\1\]', r'[\2]', resource_name)
+    if "[" not in resource_name:
+        # otherwise it can't have a quoted index
+        return resource_name
+
+    return QUOTED_INDEX_PATTERN.sub(r"[\2]", resource_name)
 
 
 def resource_reference_lookup_variants(sub_parts: list[str]) -> list[list[str]]:

--- a/tests/terraform/graph/checks/resources/S3BucketHasPublicAccessBlock/expected.yaml
+++ b/tests/terraform/graph/checks/resources/S3BucketHasPublicAccessBlock/expected.yaml
@@ -1,6 +1,7 @@
 pass:
   - "aws_s3_bucket.bucket_good_1"
   - "aws_s3_bucket.bucket_good_2"
+  - "aws_s3_bucket.bucket_good_3[0]"
 fail:
   - "aws_s3_bucket.bucket_bad_1"
   - "aws_s3_bucket.bucket_bad_2"

--- a/tests/terraform/graph/checks/resources/S3BucketHasPublicAccessBlock/expected.yaml
+++ b/tests/terraform/graph/checks/resources/S3BucketHasPublicAccessBlock/expected.yaml
@@ -2,6 +2,7 @@ pass:
   - "aws_s3_bucket.bucket_good_1"
   - "aws_s3_bucket.bucket_good_2"
   - "aws_s3_bucket.bucket_good_3[0]"
+  - "aws_s3_bucket.bucket_good_4[0]"
 fail:
   - "aws_s3_bucket.bucket_bad_1"
   - "aws_s3_bucket.bucket_bad_2"

--- a/tests/terraform/graph/checks/resources/S3BucketHasPublicAccessBlock/main.tf
+++ b/tests/terraform/graph/checks/resources/S3BucketHasPublicAccessBlock/main.tf
@@ -7,6 +7,12 @@ resource "aws_s3_bucket" "bucket_good_2" {
   bucket = "bucket_good_2"
 }
 
+// Boolean count ternary: count-expanded resources are indexed (e.g. replay[0]) and must still connect.
+resource "aws_s3_bucket" "bucket_good_3" {
+  count  = var.create_replay_bucket ? 1 : 0
+  bucket = "bucket_good_3"
+}
+
 resource "aws_s3_bucket" "bucket_bad_1" {
   bucket = "bucket_bad_1"
 }
@@ -40,6 +46,14 @@ resource "aws_s3_bucket_public_access_block" "access_good_2" {
   block_public_policy     = true
   restrict_public_buckets = true
   ignore_public_acls      = true
+}
+
+resource "aws_s3_bucket_public_access_block" "access_good_3" {
+  count  = var.create_replay_bucket ? 1 : 0
+  bucket = aws_s3_bucket.bucket_good_3[0].id
+
+  block_public_acls   = true
+  block_public_policy = true
 }
 
 resource "aws_s3_bucket_public_access_block" "access_bad_1" {

--- a/tests/terraform/graph/checks/resources/S3BucketHasPublicAccessBlock/main.tf
+++ b/tests/terraform/graph/checks/resources/S3BucketHasPublicAccessBlock/main.tf
@@ -13,6 +13,13 @@ resource "aws_s3_bucket" "bucket_good_3" {
   bucket = "bucket_good_3"
 }
 
+// Boolean count + bucket_prefix (regression for indexed graph edges)
+resource "aws_s3_bucket" "bucket_good_4" {
+  count = var.create_replay_bucket ? 1 : 0
+
+  bucket_prefix = lower("bucket-good-4-")
+}
+
 resource "aws_s3_bucket" "bucket_bad_1" {
   bucket = "bucket_bad_1"
 }
@@ -51,6 +58,14 @@ resource "aws_s3_bucket_public_access_block" "access_good_2" {
 resource "aws_s3_bucket_public_access_block" "access_good_3" {
   count  = var.create_replay_bucket ? 1 : 0
   bucket = aws_s3_bucket.bucket_good_3[0].id
+
+  block_public_acls   = true
+  block_public_policy = true
+}
+
+resource "aws_s3_bucket_public_access_block" "access_good_4" {
+  count  = var.create_replay_bucket ? 1 : 0
+  bucket = aws_s3_bucket.bucket_good_4[0].id
 
   block_public_acls   = true
   block_public_policy = true

--- a/tests/terraform/graph/checks/resources/S3BucketHasPublicAccessBlock/variables.tf
+++ b/tests/terraform/graph/checks/resources/S3BucketHasPublicAccessBlock/variables.tf
@@ -1,0 +1,7 @@
+variable "cur_bucket_name" {
+  default = "set"
+}
+
+variable "create_replay_bucket" {
+  default = true
+}

--- a/tests/terraform/graph/graph_builder/resources/count_indexed_edges/main.tf
+++ b/tests/terraform/graph/graph_builder/resources/count_indexed_edges/main.tf
@@ -1,0 +1,103 @@
+# Boolean count + bucket_prefix (customer test8 pattern)
+resource "aws_s3_bucket" "replay" {
+  count = var.create_replay_bucket ? 1 : 0
+
+  bucket_prefix = lower("checkov-replay-")
+}
+
+resource "aws_s3_bucket_public_access_block" "replay" {
+  count = var.create_replay_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.replay[0].id
+
+  block_public_acls   = true
+  block_public_policy = true
+}
+
+# Boolean count using != false ternary
+resource "aws_s3_bucket" "ne_false" {
+  count = var.create_replay_bucket != false ? 1 : 0
+
+  bucket = "checkov-ne-false-bucket"
+}
+
+resource "aws_s3_bucket_public_access_block" "ne_false" {
+  count = var.create_replay_bucket != false ? 1 : 0
+
+  bucket = aws_s3_bucket.ne_false[0].id
+
+  block_public_acls   = true
+  block_public_policy = true
+}
+
+# count.index pairing across two instances
+resource "aws_s3_bucket" "multi" {
+  count = var.replica_count
+
+  bucket = "checkov-multi-${count.index}"
+}
+
+resource "aws_s3_bucket_public_access_block" "multi" {
+  count = var.replica_count
+
+  bucket = aws_s3_bucket.multi[count.index].id
+
+  block_public_acls   = true
+  block_public_policy = true
+}
+
+# No count on bucket; dependent still references [0] — stripped-name fallback
+resource "aws_s3_bucket" "static" {
+  bucket = "checkov-static-bucket"
+}
+
+resource "aws_s3_bucket_public_access_block" "static" {
+  count = var.enable_static ? 1 : 0
+
+  bucket = aws_s3_bucket.static[0].id
+
+  block_public_acls   = true
+  block_public_policy = true
+}
+
+# Interpolation wrapper around indexed reference
+resource "aws_s3_bucket" "interp" {
+  count = var.create_replay_bucket ? 1 : 0
+
+  bucket = "checkov-interp-bucket"
+}
+
+resource "aws_s3_bucket_public_access_block" "interp" {
+  count = var.create_replay_bucket ? 1 : 0
+
+  bucket = "${aws_s3_bucket.interp[0].id}"
+
+  block_public_acls   = true
+  block_public_policy = true
+}
+
+# Versioning graph check (CKV_AWS_21) with boolean count
+resource "aws_s3_bucket" "versioned" {
+  count = var.create_replay_bucket ? 1 : 0
+
+  bucket_prefix = lower("checkov-versioned-")
+}
+
+resource "aws_s3_bucket_versioning" "versioned" {
+  count = var.create_replay_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.versioned[0].id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "versioned" {
+  count = var.create_replay_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.versioned[0].id
+
+  block_public_acls   = true
+  block_public_policy = true
+}

--- a/tests/terraform/graph/graph_builder/resources/count_indexed_edges/variables.tf
+++ b/tests/terraform/graph/graph_builder/resources/count_indexed_edges/variables.tf
@@ -1,0 +1,11 @@
+variable "create_replay_bucket" {
+  default = true
+}
+
+variable "replica_count" {
+  default = 2
+}
+
+variable "enable_static" {
+  default = true
+}

--- a/tests/terraform/graph/graph_builder/test_count_indexed_edges.py
+++ b/tests/terraform/graph/graph_builder/test_count_indexed_edges.py
@@ -1,0 +1,117 @@
+import os
+from unittest import TestCase
+
+from checkov.common.graph.db_connectors.networkx.networkx_db_connector import NetworkxConnector
+from checkov.common.output.report import Report
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.graph_builder.graph_components.block_types import BlockType
+from checkov.terraform.graph_manager import TerraformGraphManager
+from checkov.terraform.runner import Runner
+
+TEST_DIRNAME = os.path.dirname(os.path.realpath(__file__))
+RESOURCES_DIR = os.path.join(TEST_DIRNAME, "resources/count_indexed_edges")
+
+
+class TestCountIndexedEdges(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.graph_manager = TerraformGraphManager(db_connector=NetworkxConnector())
+        cls.local_graph, _ = cls.graph_manager.build_graph_from_source_directory(
+            RESOURCES_DIR, render_variables=True
+        )
+
+    def _vertex(self, name: str):
+        indices = self.local_graph.vertices_block_name_map[BlockType.RESOURCE].get(name, [])
+        self.assertEqual(len(indices), 1, f"expected exactly one vertex named {name}, found {len(indices)}")
+        return self.local_graph.vertices[indices[0]]
+
+    def _assert_bucket_edge(self, pab_name: str, bucket_name: str) -> None:
+        pab = self._vertex(pab_name)
+        bucket = self._vertex(bucket_name)
+        matching = [
+            edge for edge in self.local_graph.edges
+            if self.local_graph.vertices[edge.origin].name == pab.name
+            and self.local_graph.vertices[edge.dest].name == bucket.name
+            and edge.label == "bucket"
+        ]
+        self.assertTrue(
+            matching,
+            f"expected bucket edge from {pab_name} to {bucket_name}, "
+            f"edges={[edge.label for edge in self.local_graph.edges if self.local_graph.vertices[edge.origin].name == pab.name]}",
+        )
+
+    def test_bool_count_bucket_prefix_connects_pab(self) -> None:
+        self._assert_bucket_edge(
+            "aws_s3_bucket_public_access_block.replay[0]",
+            "aws_s3_bucket.replay[0]",
+        )
+
+    def test_bool_count_ne_false_connects_pab(self) -> None:
+        self._assert_bucket_edge(
+            "aws_s3_bucket_public_access_block.ne_false[0]",
+            "aws_s3_bucket.ne_false[0]",
+        )
+
+    def test_count_index_pairs_connect_each_instance(self) -> None:
+        self._assert_bucket_edge(
+            "aws_s3_bucket_public_access_block.multi[0]",
+            "aws_s3_bucket.multi[0]",
+        )
+        self._assert_bucket_edge(
+            "aws_s3_bucket_public_access_block.multi[1]",
+            "aws_s3_bucket.multi[1]",
+        )
+
+    def test_unexpanded_bucket_with_bracket_zero_reference_connects(self) -> None:
+        self._assert_bucket_edge(
+            "aws_s3_bucket_public_access_block.static[0]",
+            "aws_s3_bucket.static",
+        )
+
+    def test_interpolated_indexed_reference_connects(self) -> None:
+        self._assert_bucket_edge(
+            "aws_s3_bucket_public_access_block.interp[0]",
+            "aws_s3_bucket.interp[0]",
+        )
+
+    def test_versioning_connects_with_bool_count(self) -> None:
+        versioning = self._vertex("aws_s3_bucket_versioning.versioned[0]")
+        bucket = self._vertex("aws_s3_bucket.versioned[0]")
+        matching = [
+            edge for edge in self.local_graph.edges
+            if self.local_graph.vertices[edge.origin].name == versioning.name
+            and self.local_graph.vertices[edge.dest].name == bucket.name
+            and edge.label == "bucket"
+        ]
+        self.assertTrue(matching, "expected versioning resource to connect to its bucket")
+
+    def _run_check(self, check_id: str) -> Report:
+        runner = Runner()
+        return runner.run(
+            root_folder=RESOURCES_DIR,
+            runner_filter=RunnerFilter(framework=["terraform"], checks=[check_id]),
+        )
+
+    def test_ckv2_aws_6_passes_for_all_count_scenarios(self) -> None:
+        report = self._run_check("CKV2_AWS_6")
+        passed_resources = {record.resource for record in report.passed_checks}
+        expected_passed = {
+            "aws_s3_bucket.replay[0]",
+            "aws_s3_bucket.ne_false[0]",
+            "aws_s3_bucket.multi[0]",
+            "aws_s3_bucket.multi[1]",
+            "aws_s3_bucket.static",
+            "aws_s3_bucket.interp[0]",
+            "aws_s3_bucket.versioned[0]",
+        }
+        self.assertFalse(report.failed_checks, report.failed_checks)
+        self.assertTrue(expected_passed.issubset(passed_resources), passed_resources)
+
+    def test_ckv_aws_21_passes_for_versioned_bucket(self) -> None:
+        report = self._run_check("CKV_AWS_21")
+        passed_resources = {record.resource for record in report.passed_checks}
+        self.assertIn("aws_s3_bucket.versioned[0]", passed_resources)
+        self.assertFalse(
+            [r for r in report.failed_checks if r.resource == "aws_s3_bucket.versioned[0]"],
+            report.failed_checks,
+        )

--- a/tests/terraform/graph/utils/test_utils.py
+++ b/tests/terraform/graph/utils/test_utils.py
@@ -40,6 +40,23 @@ class TestUtils(TestCase):
         for i in range(0, len(str_values)):
             self.assertEqual(expected[i], get_referenced_vertices_in_value(str_values[i], aliases, ['aws_vpc', 'aws_instance']))
 
+    def test_preserve_resource_index_in_references(self):
+        aliases: dict = {}
+        resources_types = ['aws_s3_bucket']
+        expected_stripped = [TerraformVertexReference(BlockType.RESOURCE, ['aws_s3_bucket.replay', 'id'], 'aws_s3_bucket.replay.id')]
+        expected_indexed = [TerraformVertexReference(BlockType.RESOURCE, ['aws_s3_bucket.replay[0]', 'id'], 'aws_s3_bucket.replay[0].id')]
+
+        self.assertEqual(
+            expected_stripped,
+            get_referenced_vertices_in_value('aws_s3_bucket.replay[0].id', aliases, resources_types),
+        )
+        self.assertEqual(
+            expected_indexed,
+            get_referenced_vertices_in_value(
+                'aws_s3_bucket.replay[0].id', aliases, resources_types, preserve_resource_index=True
+            ),
+        )
+
     def test_replace_map_attribute_access_with_dot(self):
         str_value = 'data.aws_availability_zones["available"].names[1]'
         replace_map_attribute_access_with_dot(str_value)

--- a/tests/terraform/graph/utils/test_utils.py
+++ b/tests/terraform/graph/utils/test_utils.py
@@ -6,7 +6,8 @@ from checkov.common.graph.graph_builder.graph_components.attribute_names import 
 from checkov.terraform.graph_builder.graph_components.block_types import BlockType
 from checkov.terraform.graph_builder.utils import get_referenced_vertices_in_value, \
     replace_map_attribute_access_with_dot, generate_possible_strings_from_wildcards, \
-    attribute_has_nested_attributes
+    attribute_has_nested_attributes, normalize_terraform_resource_index_name, \
+    resource_reference_lookup_variants
 from checkov.terraform.graph_builder.variable_rendering.vertex_reference import TerraformVertexReference
 from checkov.terraform.graph_builder.local_graph import update_dictionary_attribute
 
@@ -56,6 +57,50 @@ class TestUtils(TestCase):
                 'aws_s3_bucket.replay[0].id', aliases, resources_types, preserve_resource_index=True
             ),
         )
+
+    def test_preserve_resource_index_in_list_and_interpolation(self):
+        aliases: dict = {}
+        resources_types = ['aws_s3_bucket']
+        expected = [TerraformVertexReference(BlockType.RESOURCE, ['aws_s3_bucket.replay[1]', 'id'], 'aws_s3_bucket.replay[1].id')]
+
+        self.assertEqual(
+            expected,
+            get_referenced_vertices_in_value(
+                ['aws_s3_bucket.replay[1].id'], aliases, resources_types, preserve_resource_index=True
+            ),
+        )
+        self.assertEqual(
+            expected,
+            get_referenced_vertices_in_value(
+                '${aws_s3_bucket.replay[1].id}', aliases, resources_types, preserve_resource_index=True
+            ),
+        )
+
+    def test_preserve_resource_index_with_quoted_index(self):
+        aliases: dict = {}
+        resources_types = ['aws_s3_bucket']
+        expected = [
+            TerraformVertexReference(
+                BlockType.RESOURCE, ['aws_s3_bucket.multi["0"]', 'id'], 'aws_s3_bucket.multi["0"].id'
+            )
+        ]
+        self.assertEqual(
+            expected,
+            get_referenced_vertices_in_value(
+                'aws_s3_bucket.multi["0"].id', aliases, resources_types, preserve_resource_index=True
+            ),
+        )
+
+    def test_normalize_terraform_resource_index_name(self):
+        self.assertEqual(
+            'aws_s3_bucket.multi[0]',
+            normalize_terraform_resource_index_name('aws_s3_bucket.multi["0"]'),
+        )
+
+    def test_resource_reference_lookup_variants(self):
+        variants = resource_reference_lookup_variants(['aws_s3_bucket.multi["0"]', 'id'])
+        self.assertIn(['aws_s3_bucket.multi[0]', 'id'], variants)
+        self.assertIn(['aws_s3_bucket.multi', 'id'], variants)
 
     def test_replace_map_attribute_access_with_dot(self):
         str_value = 'data.aws_availability_zones["available"].names[1]'

--- a/tests/terraform/graph/utils/test_utils.py
+++ b/tests/terraform/graph/utils/test_utils.py
@@ -41,44 +41,48 @@ class TestUtils(TestCase):
         for i in range(0, len(str_values)):
             self.assertEqual(expected[i], get_referenced_vertices_in_value(str_values[i], aliases, ['aws_vpc', 'aws_instance']))
 
-    def test_preserve_resource_index_in_references(self):
+    def test_include_indexed_references(self):
         aliases: dict = {}
         resources_types = ['aws_s3_bucket']
-        expected_stripped = [TerraformVertexReference(BlockType.RESOURCE, ['aws_s3_bucket.replay', 'id'], 'aws_s3_bucket.replay.id')]
-        expected_indexed = [TerraformVertexReference(BlockType.RESOURCE, ['aws_s3_bucket.replay[0]', 'id'], 'aws_s3_bucket.replay[0].id')]
+        stripped = TerraformVertexReference(BlockType.RESOURCE, ['aws_s3_bucket.replay', 'id'], 'aws_s3_bucket.replay.id')
+        indexed = TerraformVertexReference(BlockType.RESOURCE, ['aws_s3_bucket.replay[0]', 'id'], 'aws_s3_bucket.replay[0].id')
 
         self.assertEqual(
-            expected_stripped,
+            [stripped],
             get_referenced_vertices_in_value('aws_s3_bucket.replay[0].id', aliases, resources_types),
         )
         self.assertEqual(
-            expected_indexed,
+            [stripped, indexed],
             get_referenced_vertices_in_value(
-                'aws_s3_bucket.replay[0].id', aliases, resources_types, preserve_resource_index=True
+                'aws_s3_bucket.replay[0].id', aliases, resources_types, include_indexed_references=True
             ),
         )
 
-    def test_preserve_resource_index_in_list_and_interpolation(self):
+    def test_include_indexed_references_in_list_and_interpolation(self):
         aliases: dict = {}
         resources_types = ['aws_s3_bucket']
-        expected = [TerraformVertexReference(BlockType.RESOURCE, ['aws_s3_bucket.replay[1]', 'id'], 'aws_s3_bucket.replay[1].id')]
+        expected = [
+            TerraformVertexReference(BlockType.RESOURCE, ['aws_s3_bucket.replay', 'id'], 'aws_s3_bucket.replay.id'),
+            TerraformVertexReference(BlockType.RESOURCE, ['aws_s3_bucket.replay[1]', 'id'], 'aws_s3_bucket.replay[1].id'),
+        ]
 
         self.assertEqual(
             expected,
             get_referenced_vertices_in_value(
-                ['aws_s3_bucket.replay[1].id'], aliases, resources_types, preserve_resource_index=True
+                ['aws_s3_bucket.replay[1].id'], aliases, resources_types, include_indexed_references=True
             ),
         )
         self.assertEqual(
             expected,
             get_referenced_vertices_in_value(
-                '${aws_s3_bucket.replay[1].id}', aliases, resources_types, preserve_resource_index=True
+                '${aws_s3_bucket.replay[1].id}', aliases, resources_types, include_indexed_references=True
             ),
         )
 
-    def test_preserve_resource_index_with_quoted_index(self):
+    def test_include_indexed_references_with_quoted_index(self):
         aliases: dict = {}
         resources_types = ['aws_s3_bucket']
+        # quoted indices are never stripped, so both pipelines agree and only one reference is returned
         expected = [
             TerraformVertexReference(
                 BlockType.RESOURCE, ['aws_s3_bucket.multi["0"]', 'id'], 'aws_s3_bucket.multi["0"].id'
@@ -87,7 +91,7 @@ class TestUtils(TestCase):
         self.assertEqual(
             expected,
             get_referenced_vertices_in_value(
-                'aws_s3_bucket.multi["0"].id', aliases, resources_types, preserve_resource_index=True
+                'aws_s3_bucket.multi["0"].id', aliases, resources_types, include_indexed_references=True
             ),
         )
 


### PR DESCRIPTION
## Summary
- Fix false positives on graph checks (e.g. `CKV2_AWS_6`) when resources use `count` with a boolean ternary like `var.create_replay_bucket ? 1 : 0`
- When `count` expands a resource, its vertex name becomes indexed (e.g. `aws_s3_bucket.replay[0]`), but edge building stripped `[0]` from references like `aws_s3_bucket.replay[0].id` and looked up `aws_s3_bucket.replay` instead — so the public access block / versioning resources were never connected in the graph
- Parse references with an optional `preserve_resource_index` flag and try indexed vertex lookup before falling back to the stripped name when building edges
## Root cause
Terraform code like this is valid and deploys correctly:
```hcl
resource "aws_s3_bucket" "replay" {
  count = var.create_replay_bucket ? 1 : 0
  ...
}
resource "aws_s3_bucket_public_access_block" "replay" {
  count  = var.create_replay_bucket ? 1 : 0
  bucket = aws_s3_bucket.replay[0].id
  ...
}
```


**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

[//]: # "
    # PR Title
    Be aware that we use the title to create changelog automatically and therefore only allow specific prefixes
    - break:    to indicate a breaking change, this supersedes any of the types
    - feat:     to indicate new features or checks
    - fix:      to indicate a bugfix or handling of edge cases of existing checks
    - docs:     to indicate an update to our documentation
    - chore:    to indicate adjustments to workflow files or dependency updates
    - platform: to indicate a change needed for the platform
    Additionally a scope is needs to be added to the prefix, which indicates the targeted framework, in doubt choose 'general'.
    #    
    Allowed prefixs:
    ansible|argo|arm|azure|bicep|bitbucket|circleci|cloudformation|dockerfile|github|gha|gitlab|helm|kubernetes|kustomize|openapi|sca|secrets|serverless|terraform|general|graph|terraform_plan|terraform_json
    #
    ex.
    feat(terraform): add CKV_AWS_123 to ensure that VPC Endpoint Service is configured for Manual Acceptance
"

## Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes # (issue)

## New/Edited policies (Delete if not relevant)

### Description
*Include a description of what makes it a violation and any relevant external links.*

### Fix
*How does someone fix the issue in code and/or in runtime?*

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feature, policy, or fix is effective and works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added resource reference lookup variants and normalized quoted index handling
* Expanded edge-case tests and removed unused import from codebase

**🐛 Bugfixes**
* Fixed graph-edge connections for count-expanded Terraform resource references

**🔧 Refactors**
* Precompiled quoted-index regex and avoided redundant lookup calls


<sup>[More info](https://app.aikido.dev/featurebranch/scan/153432199?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->